### PR TITLE
Jaro-Winkler bug fix: A compared to B does not equal B compared to A

### DIFF
--- a/php/JaroWinkler.php
+++ b/php/JaroWinkler.php
@@ -43,7 +43,7 @@ function getCommonCharacters( $string1, $string2, $allowedDistance ){
   $str2_len = strlen($string2);
   $temp_string2 = $string2;
    
-  $commonCharacters='';
+  $commonCharacters = [];
 
   for( $i=0; $i < $str1_len; $i++){
     
@@ -55,14 +55,14 @@ function getCommonCharacters( $string1, $string2, $allowedDistance ){
       if( $temp_string2[$j] == $string1[$i] ){
         $noMatch = False;
 
-	$commonCharacters .= $string1[$i];
+	$commonCharacters[$string1[$i]] = $string1[$i];
 
 	$temp_string2[$j] = '';
       }
     }
   }
 
-  return $commonCharacters;
+  return implode("", $commonCharacters);
 }
   
 function Jaro( $string1, $string2 ){


### PR DESCRIPTION
Currently, string A compared to string B will yield a different result to string B compared to string A, when either string A or B contains a character found in both strings, that is found more than once in one of the string. This is incorrect. The Jaro-Winkler method should yield the same result when comparing the match value from A compared to B with B compared to A.

To rectify this, when identifying the common characters, the same character should not be repeated. The common characters variable needs to be deduplicated before returned.

This fix replaces the common characters string with an array that uses the common character as the key, to avoid duplication. By running the updated method, A compared to B yields the same results as B compared to A.

This is inline with the C# version of the method.