### PR TITLE
[bug fix] PHP Warning:  Cannot assign an empty string to a string offset and different result of comparation of two string

### DIFF
--- a/php/JaroWinkler.php
+++ b/php/JaroWinkler.php
@@ -41,7 +41,7 @@ function getCommonCharacters( $string1, $string2, $allowedDistance ){
   
   $str1_len = strlen($string1);
   $str2_len = strlen($string2);
-  $temp_string2 = $string2;
+  $temp_string2 = str_plit($string2);
    
   $commonCharacters='';
 


### PR DESCRIPTION
This is a simple update to fix the issue about compare A to B doesn't equal B to A. This update also fix the "PHP Warning:  Cannot assign an empty string to a string offset"  on line 60 => $temp_string2[$j] = ''; because can not insert empty character ('') to a string.